### PR TITLE
Replace outdated charter info on Council page

### DIFF
--- a/council.md
+++ b/council.md
@@ -16,7 +16,7 @@ to talk and coordinate regularly, and thus sustain international collaboration.
 
 The Council consists of delegates from the established RSE associations, who
 meet regularly to coordinate, discuss and collaborate. It is governed by a 
-charter (currently being drafted). Further national or multinational RSE 
+[charter](council/charter.html). Further national or multinational RSE 
 associations can join the Council once they pass a threshold for establishment 
 that is defined in the charter.
 


### PR DESCRIPTION
This PR removes an outdated bit about the charter being drafted from the Council page.