### PR TITLE
Fix #83: Add Council events page

### DIFF
--- a/council.md
+++ b/council.md
@@ -55,4 +55,4 @@ The Council has a [*Code of Conduct*](./council/code-of-conduct.md), and you are
 
 ## Events
 
-Have a look at the [Council Events](council/events.html) page for a list of events run by member associations.
+Have a look at the [Council Events](council/events.html) page for a list of events run by member associations of potential international interest. Note that, in addition, most associations maintain their own complete list of their events.

--- a/council.md
+++ b/council.md
@@ -34,8 +34,8 @@ For more information, also read
 Read the [Charter of the International Council of RSE Associations](council/charter.html) or download it as a [PDF file](International-Council-of-RSE-Associations_Charter.pdf).
 
 The Council has a [*Code of Conduct*](./council/code-of-conduct.md), and you are expected to honour it in any participation in or interaction with the Council.
-
-## Current members
+  
+## Current member associations and representatives
 
 | Association | Name | Email |
 | -----------: | :--------------| :--------------|
@@ -52,3 +52,7 @@ The Council has a [*Code of Conduct*](./council/code-of-conduct.md), and you are
 | Nordic-RSE  | Radovan Bast | radovan.bast@uit.no |
 | US-RSE  | Daniel S. Katz | d.katz@ieee.org |
 | US-RSE  | Nicole Brewer | brewer36@purdue.edu |
+
+## Events
+
+Have a look at the [Council Events](council/events.html) page for a list of events run by member associations.

--- a/council/events.md
+++ b/council/events.md
@@ -4,10 +4,15 @@ title: The International Council of RSE Associations - Events
 hidetitle: false
 ---
 
-The following is a list of events run by member associations of potential international interest. Note that, in addition, most associations maintain their own complete list of their events.
+The following is a list of events run by member associations of potential international interest. Note that, in addition, most associations maintain their own complete list of their events. You can find a [list of links to association event pages at the bottom of this page](#association-event-pages).
 
-# 2022
+## 2022 <!-- Strangely, h2 is larger than h1 -->
 
 # February
 
 - **21 Feb - 25 Feb** - *Germany* - online - [rSE22 Workshops](https://se-2022.gi.de/rse22workshops) and [rSE22 Talks](https://se-2022.gi.de/program/rse-workshops-und-bof) tracks at the Software Engineering 2022 conference \[*languages: EN/DE*\]
+
+## Association Event Pages
+
+- **de-RSE**: <https://de-rse.org/en/events.html>
+- **US-RSE**: <https://us-rse.org/events/>

--- a/council/events.md
+++ b/council/events.md
@@ -4,7 +4,7 @@ title: The International Council of RSE Associations - Events
 hidetitle: false
 ---
 
-The following is a list of events run by member associations.
+The following is a list of events run by member associations of potential international interest. Note that, in addition, most associations maintain their own complete list of their events.
 
 # 2022
 

--- a/council/events.md
+++ b/council/events.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: The International Council of RSE Associations - Events
+hidetitle: false
+---
+
+The following is a list of events run by member associations.
+
+# 2022
+
+# February
+
+- **21 Feb - 25 Feb** - *Germany* - online - [rSE22 Workshops](https://se-2022.gi.de/rse22workshops) and [rSE22 Talks](https://se-2022.gi.de/program/rse-workshops-und-bof) tracks at the Software Engineering 2022 conference \[*languages: EN/DE*\]


### PR DESCRIPTION
Fixes issue #83:

- Add a simple page for events run by member associations
- Link to the events page from the Council landing page