### PR TITLE
Add events page proper

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ header_pages:
 # - 2020-workshop.md
   - assoc.md
   - council.md
+  - events.md
   - contact.md
 # - code-of-conduct.md
 # - communication.md

--- a/council.md
+++ b/council.md
@@ -52,7 +52,3 @@ The Council has a [*Code of Conduct*](./council/code-of-conduct.md), and you are
 | Nordic-RSE  | Radovan Bast | radovan.bast@uit.no |
 | US-RSE  | Daniel S. Katz | d.katz@ieee.org |
 | US-RSE  | Nicole Brewer | brewer36@purdue.edu |
-
-## Events
-
-Have a look at the [Council Events](council/events.html) page for a list of events run by member associations of potential international interest. Note that, in addition, most associations maintain their own complete list of their events.

--- a/events.md
+++ b/events.md
@@ -1,10 +1,12 @@
 ---
 layout: page
-title: The International Council of RSE Associations - Events
-hidetitle: false
+title: Events
+hidetitle: true
 ---
 
-The following is a list of events run by member associations of potential international interest. Note that, in addition, most associations maintain their own complete list of their events. You can find a [list of links to association event pages at the bottom of this page](#association-event-pages).
+## International RSE Events
+
+The following is a list of events run by member associations of the International RSE Council that are of potential international interest. Note that, in addition, most associations maintain their own complete list of their events. You can find a [list of links to national association event pages at the bottom of this page](#association-event-pages).
 
 ## 2022 <!-- Strangely, h2 is larger than h1 -->
 


### PR DESCRIPTION
This PR fixes #91 and fixes #7 by

- Moving the events page to the main body of the website
- Adding a link to the navigation header
- Adapting the page to slightly move scope away from just the Council
- Remove section on council page that links to ex-Council events page