### PR TITLE
Update content for 2nd intl RSE day

### DIFF
--- a/council/intl-rse-day.md
+++ b/council/intl-rse-day.md
@@ -7,7 +7,7 @@ hidetitle: false
 The [International Council of RSE Associations](../council.md) has decided to declare 
 the second Thursday in October to be the annual "International RSE Day". 
 
-### The first International RSE Day will be<br>*Thursday, 14th October 2021*.
+### The second International RSE Day will be<br>*Thursday, 13th October 2022*.
 
 The International RSE Day is to celebrate Research Software Engineers around the world 
 and raise awareness for the increasingly relevant discipline of Research Software 
@@ -20,14 +20,21 @@ hold regular or special events on this day, such as:
 * Awareness campaigns
 * National RSE information sessions
 
-## International RSE Day 2021 - Events
+## International RSE Day 2022 - Events
 
-- ### **[NL-RSE]** [NL-RSE Road Show](https://nl-rse.org/events/NL-RSE-RSE21.html)
-- ### **[Nordic-RSE]** [Nordic-RSE celebrates International RSE day](https://nordic-rse.org/events/international-rse-day/)
-- ### **[US-RSE]** [US-RSE International RSE Day Virtual Events](https://us-rse.org/events/2021/2021-10-intnl-rse-day)
-- ### **[de-RSE]** [de-RSE International RSE day](https://pad.gwdg.de/s/SmDzPpyOx)
-- ### **[RSE_Asia]** [RSE Asia Launch Event on International RSE day](https://rse-asia.github.io/RSE_Asia/)
+- ### **[de-RSE]** [de-RSE International RSE day](https://github.com/DE-RSE/projekte/issues/11)
 
-### Related events on Intl RSE Day
 
-- #### **[Australia]** ["Data is Only Half the Battle"](https://conference.eresearch.edu.au/events/data-is-only-half-the-battle/) - RSE & Research software management BOF
+<br/><br/>
+
+#### International RSE Day 2021 - Events
+
+- **[NL-RSE]** [NL-RSE Road Show](https://nl-rse.org/events/NL-RSE-RSE21.html)
+- **[Nordic-RSE]** [Nordic-RSE celebrates International RSE day](https://nordic-rse.org/events/international-rse-day/)
+- **[US-RSE]** [US-RSE International RSE Day Virtual Events](https://us-rse.org/events/2021/2021-10-intnl-rse-day)
+- **[de-RSE]** [de-RSE International RSE day](https://pad.gwdg.de/s/SmDzPpyOx)
+- **[RSE_Asia]** [RSE Asia Launch Event on International RSE day](https://rse-asia.github.io/RSE_Asia/)
+
+#### Related events on Intl RSE Day 2021
+
+- **[Australia]** ["Data is Only Half the Battle"](https://conference.eresearch.edu.au/events/data-is-only-half-the-battle/) - RSE & Research software management BOF

--- a/council/intl-rse-day.md
+++ b/council/intl-rse-day.md
@@ -22,7 +22,7 @@ hold regular or special events on this day, such as:
 
 ## International RSE Day 2022 - Events
 
-- ### **[de-RSE]** [de-RSE International RSE day](https://github.com/DE-RSE/projekte/issues/11)
+- ### **[de-RSE]** [de-RSE International RSE day](https://pad.gwdg.de/44b79pTvSYae9QEr8c5Dhw)
 
 
 <br/><br/>

--- a/index.md
+++ b/index.md
@@ -9,10 +9,10 @@ This is the website of the international research software engineering community
 Research Software Engineers are people who combine professional software expertise with an understanding of research. They go by various job titles but the term Research Software Engineer (RSE) is fast gaining international recognition.
 
 <div style="position: relative; height: auto; border: 2px solid #841b5f; margin: 10px auto; padding: 10px; box-sizing: border-box; background-color: #f0e1e8; border-radius: 5px;">
-<h3 style="padding: 0; margin: 0;">14th October 2021 was the first <i>International RSE Day</i>!<br>
+<h3 style="padding: 0; margin: 0;">On 13th October 2022 we're celebrating the second <i>International RSE Day</i>!<br>
 <a href="council/intl-rse-day.html">Read more ...</a></h3>
 <i>International RSE Day is the second Thursday of October each year.<br>
-  The next International RSE Day will be 13th October 2022!</i>
+  The next International RSE Day will be 12th October 2023!</i>
 </div>
 
 # National/Multinational RSE Associations


### PR DESCRIPTION
This PR updates the website content for 2nd Intl. RSE Day.

Council member associations should push to this branch (`update-intl-rse-day-info`) to update their respective info by the end of the week (*7 October*) I think, to get the info out in time.