### PR TITLE
Update council dir README to point to onboarding doc

### DIFF
--- a/council/README.md
+++ b/council/README.md
@@ -1,13 +1,5 @@
-# How to contribute to the pages of the International Council of RSE Associations
+# Contributing to the pages of the International Council of RSE Associations
 
-## What to do when member associations' representatives change? 🧑‍🤝‍🧑
+Contributions to these pages should be made by Council representatives only.
 
-Some things need to be done by different **parties** if the representatives for a member association change:
-
-1. A **member of the [GitHub team *council-members*](https://github.com/orgs/rse-council/teams/council-members)** adds new, and removes parting, representatives to/from the [GitHub team *council-members*](https://github.com/orgs/rse-council/teams/council-members).
-2. **New representatives** [create a pull request](https://github.com/rse-council/researchsoftware.org/edit/main/council.md) that removes the information of parting representatives from, and adds their own information to, the [list of representatives on the main Council page](https://github.com/rse-council/researchsoftware.org/blob/main/council.md#current-members).  
-**Current representatives** review the pull request, and add new representatives to the list of contributors of the website. This is done via the [All Contributors bot](https://allcontributors.org/docs/en/bot/usage) by commenting on the pull request: `@all-contributors please add @<username-of-the-new-representative> for content`.
-3. **New representatives** subscribe to the [internal RSE Council mailing list](https://www.listserv.dfn.de/sympa/subscribe/intl-rse-council-internal) and the [public RSE Council mailing list](https://www.listserv.dfn.de/sympa/subscribe/intl-rse-council).  
-The **mailing list moderators** remove parting representatives from the internal mailing list.
-4. **New representatives** join the [UK RSE Slack workspace](https://society-rse.org/join-us/#slack), and ask the internal mailing list to be added to the channel [#intl-rse-council](https://ukrse.slack.com/archives/G01KNLPLJ85).  
-**Current representatives** add new representatives to the channel and remove parting representatives.
+If you're a new representative and need to update representative information, please ask another member for access to the shared folder. This folder contains a document called "Onboarding for new Council members", which contains all the necessary information to gain access.


### PR DESCRIPTION
- As of today, the information that used to be here now lives in the document referenced in this change (on Google Drive).
- All Council representatives should have access to this shared folder.